### PR TITLE
Fix preflight check timing: move after OCI CLI installation

### DIFF
--- a/.github/workflows/free-tier-creation.yml
+++ b/.github/workflows/free-tier-creation.yml
@@ -63,21 +63,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Production preflight check
-        env:
-          OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
-          OCI_KEY_FINGERPRINT: ${{ secrets.OCI_KEY_FINGERPRINT }}
-          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
-          OCI_REGION: ${{ secrets.OCI_REGION }}
-          OCI_PRIVATE_KEY: ${{ secrets.OCI_PRIVATE_KEY }}
-          OCI_COMPARTMENT_ID: ${{ secrets.OCI_COMPARTMENT_ID }}
-          OCI_SUBNET_ID: ${{ secrets.OCI_SUBNET_ID }}
-          OCI_IMAGE_ID: ${{ secrets.OCI_IMAGE_ID }}
-          INSTANCE_SSH_PUBLIC_KEY: ${{ secrets.INSTANCE_SSH_PUBLIC_KEY }}
-          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
-          TELEGRAM_USER_ID: ${{ secrets.TELEGRAM_USER_ID }}
-        run: ./scripts/preflight-check.sh
-
       - name: Create requirements file
         run: echo "oci-cli" > requirements.txt
 
@@ -102,6 +87,21 @@ jobs:
 
       - name: Install OCI CLI
         run: pip install --user -r requirements.txt
+
+      - name: Production preflight check
+        env:
+          OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
+          OCI_KEY_FINGERPRINT: ${{ secrets.OCI_KEY_FINGERPRINT }}
+          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
+          OCI_REGION: ${{ secrets.OCI_REGION }}
+          OCI_PRIVATE_KEY: ${{ secrets.OCI_PRIVATE_KEY }}
+          OCI_COMPARTMENT_ID: ${{ secrets.OCI_COMPARTMENT_ID }}
+          OCI_SUBNET_ID: ${{ secrets.OCI_SUBNET_ID }}
+          OCI_IMAGE_ID: ${{ secrets.OCI_IMAGE_ID }}
+          INSTANCE_SSH_PUBLIC_KEY: ${{ secrets.INSTANCE_SSH_PUBLIC_KEY }}
+          TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
+          TELEGRAM_USER_ID: ${{ secrets.TELEGRAM_USER_ID }}
+        run: ./scripts/preflight-check.sh
 
       - name: Setup OCI and SSH configuration (parallel)
         env:


### PR DESCRIPTION
## Summary
- Move preflight check step after OCI CLI installation in GitHub Actions workflow
- Resolves failure in scheduled workflow run 17216548356

## Problem
The preflight check was running before OCI CLI installation, causing it to fail when validating OCI CLI availability. The workflow sequence was:
1. Checkout → **Preflight check** (fails - no OCI CLI) → Install Python → Install OCI CLI

## Solution
Reordered workflow steps to ensure OCI CLI is available before preflight validation:
1. Checkout → Install Python → Install OCI CLI → **Preflight check** (succeeds)

## Test Plan
- [x] Workflow syntax validated
- [x] All preflight check functionality preserved
- [x] No breaking changes to existing configuration

🤖 Generated with [Claude Code](https://claude.ai/code)