### PR TITLE
Fix super-linter GitHub Status API 403 errors

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,6 +13,8 @@ on:
     branches: [ "master" ]
 permissions:
   contents: read
+  statuses: write      # Allow updating commit statuses
+  pull-requests: write # Allow PR comments
 jobs:
   run-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Fix GitHub Status API 403 errors in super-linter workflow
- Add required permissions: `statuses: write` and `pull-requests: write`
- Resolves workflow failures in run 17244600917

## Problem
Super Linter v4.10.0 was failing with "Failed to call GitHub Status API" 403 errors because the workflow only had `contents: read` permission. The linter attempts to update commit statuses but lacks the necessary write permissions.

## Solution
Added the missing permissions to `.github/workflows/super-linter.yml`:
- `statuses: write` - Allows updating commit statuses via GitHub API
- `pull-requests: write` - Enables PR comments for inline feedback

## Testing
This change will be validated when the PR triggers the super-linter workflow, which should now complete without 403 errors.