### PR TITLE
[skip-review] Final fixes for claude review bot; disable custom GH token

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -90,21 +90,21 @@ jobs:
           additional_permissions: |
             actions: read
           # Github_token should not be needed - uses default GITHUB_TOKEN for GitHub operations
-          # setting it for now as a fix to HttpError: Resource not accessible by integration - https://docs.github.com
-          github_token: ${{ secrets.CLAUDE_CODE_GH_PAT }}
+          # setting it for now fixes HttpError: Resource not accessible by integration - https://docs.github.com[...]
+          # github_token: ${{ secrets.CLAUDE_CODE_GH_PAT }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Use just one comment to deliver PR comments (only applies for pull_request event workflows)
-          # use_sticky_comment: true
+          use_sticky_comment: true
           # Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands
-          # use_commit_signing: true
+          use_commit_signing: true
           claude_args: |
             --max-turns 15
             --model claude-opus-4-1-20250805
-            --system-prompt "You are a senior engineer focused on code quality"
-            --allowedTools "Task,Bash,Glob,Grep,LS,ExitPlanMode,Read,Edit,MultiEdit,Write,NotebookEdit,TodoWrite,BashOutput,KillBash,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,mcp__github_comment__update_claude_comment,mcp__github__add_comment_to_pending_review,mcp__github__create_and_submit_pull_request_review,mcp__github__create_issue,mcp__github__create_or_update_file,mcp__github__create_pending_pull_request_review,mcp__github__delete_pending_pull_request_review,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_file_contents,mcp__github__get_job_logs,mcp__github__get_me,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_secret_scanning_alert,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_pull_requests,mcp__github__list_secret_scanning_alerts,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__merge_pull_request,mcp__github__push_files,mcp__github__rerun_failed_jobs,mcp__github__rerun_workflow_run,mcp__github__run_workflow,mcp__github__search_code,mcp__github__search_pull_requests,mcp__github__submit_pending_pull_request_review,mcp__github__update_pull_request,mcp__github__update_pull_request_branch,ListMcpResourcesTool,ReadMcpResourceTool"
+            --system-prompt "You are a senior engineer focused on code quality. You are a performance optimization expert. Focus on identifying bottlenecks and suggesting improvements."
+            --allowedTools "Task,Bash,Glob,Grep,LS,ExitPlanMode,Read,Edit,MultiEdit,Write,NotebookEdit,TodoWrite,BashOutput,KillBash,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,mcp__github_comment__update_claude_comment,mcp__github__add_comment_to_pending_review,mcp__github__create_and_submit_pull_request_review,mcp__github__create_issue,mcp__github__create_or_update_file,mcp__github__create_pending_pull_request_review,mcp__github__delete_pending_pull_request_review,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_file_contents,mcp__github__get_job_logs,mcp__github__get_me,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_secret_scanning_alert,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_pull_requests,mcp__github__list_secret_scanning_alerts,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__merge_pull_request,mcp__github__push_files,mcp__github__rerun_failed_jobs,mcp__github__rerun_workflow_run,mcp__github__run_workflow,mcp__github__search_code,mcp__github__search_pull_requests,mcp__github__submit_pending_pull_request_review,mcp__github__update_pull_request,mcp__github__update_pull_request_branch,mcp__github_file_ops__commit_files,mcp__github_file_ops__delete_files,mcp_github_file_ops_server__search_files,mcp_github_file_ops_server__file_search,mcp_github_file_ops_server__read_file,ListMcpResourcesTool,ReadMcpResourceTool"
             --disallowedTools WebSearch,WebFetch
           prompt: |
-            Please review this pull request with comprehensive analysis covering both general software engineering principles and OCI automation specifics:
+            Please review this PR #${{ github.event.pull_request.number }} in ${{ github.repository }} with comprehensive analysis covering both general software engineering principles and OCI automation specifics:
 
             **General Code Quality & Best Practices:**
             - Code structure, readability, and maintainability
@@ -151,5 +151,6 @@ jobs:
             - Workflow and automation reliability
 
             Be constructive, thorough, and provide specific actionable feedback.
+            Provide severity ratings (Critical/High/Medium/Low) for any issues found.
             Use GitHub's suggestion format when proposing code changes.
             Use inline comments to highlight specific areas of concern.


### PR DESCRIPTION
In https://github.com/senomorf/OracleInstanceCreator/pull/15 claude reviewer was creating review comment as my own comment because of custom PAT token. Fixing that; also attempting to enable signed commits and sticky comment now when general review functionality seems to be working with v1