### PR TITLE
[skip-review] Updates and fixes to claude code review bot workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,18 +42,21 @@ jobs:
           fetch-depth: 0 # Full history for better diff analysis
 
       - name: Setup Bun
+        id: setup-bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - name: Cache Bun dependencies
+      - name: Cache Bun dependencies & Claude Installer
         uses: actions/cache@v4
         with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-claude-action-${{ hashFiles('**/bun.lockb') }}
+          path: |
+            ~/.bun/install/cache
+            ~/.claude/downloads
+          key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-version }}-claude-action-${{ hashFiles('**/bun.lockb', '**/.claude/downloads/*')  }}
           restore-keys: |
-            ${{ runner.os }}-bun-claude-action-
-            ${{ runner.os }}-bun-
+            ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-version }}-claude-action-
+            ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-version }}-
 
       - name: Pre-install dependencies with retry
         run: |
@@ -95,17 +98,17 @@ jobs:
           # github_token: ${{ secrets.CLAUDE_CODE_GH_PAT }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Use just one comment to deliver PR comments (only applies for pull_request event workflows)
-          use_sticky_comment: true
+          # use_sticky_comment: true
           # Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands
-          use_commit_signing: true
+          # use_commit_signing: true
           claude_args: |
             --max-turns 15
             --model claude-opus-4-1-20250805
             --system-prompt "You are a senior engineer focused on code quality. You are a performance optimization expert. Focus on identifying bottlenecks and suggesting improvements."
-            --allowedTools "Task,Bash,Glob,Grep,LS,ExitPlanMode,Read,Edit,MultiEdit,Write,NotebookEdit,TodoWrite,BashOutput,KillBash,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,mcp__github_comment__update_claude_comment,mcp__github__add_comment_to_pending_review,mcp__github__create_and_submit_pull_request_review,mcp__github__create_issue,mcp__github__create_or_update_file,mcp__github__create_pending_pull_request_review,mcp__github__delete_pending_pull_request_review,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_file_contents,mcp__github__get_job_logs,mcp__github__get_me,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_secret_scanning_alert,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_pull_requests,mcp__github__list_secret_scanning_alerts,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__merge_pull_request,mcp__github__push_files,mcp__github__rerun_failed_jobs,mcp__github__rerun_workflow_run,mcp__github__run_workflow,mcp__github__search_code,mcp__github__search_pull_requests,mcp__github__submit_pending_pull_request_review,mcp__github__update_pull_request,mcp__github__update_pull_request_branch,mcp__github_file_ops__commit_files,mcp__github_file_ops__delete_files,mcp_github_file_ops_server__search_files,mcp_github_file_ops_server__file_search,mcp_github_file_ops_server__read_file,ListMcpResourcesTool,ReadMcpResourceTool"
+            --allowedTools "Task,Bash,Glob,Grep,LS,ExitPlanMode,Read,Edit,MultiEdit,Write,NotebookEdit,TodoWrite,BashOutput,KillBash,mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,mcp__github_comment__update_claude_comment,mcp__github__add_comment_to_pending_review,mcp__github__create_and_submit_pull_request_review,mcp__github__create_issue,mcp__github__create_or_update_file,mcp__github__create_pending_pull_request_review,mcp__github__delete_pending_pull_request_review,mcp__github__download_workflow_run_artifact,mcp__github__get_code_scanning_alert,mcp__github__get_commit,mcp__github__get_dependabot_alert,mcp__github__get_file_contents,mcp__github__get_job_logs,mcp__github__get_me,mcp__github__get_pull_request,mcp__github__get_pull_request_comments,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_files,mcp__github__get_pull_request_reviews,mcp__github__get_pull_request_status,mcp__github__get_secret_scanning_alert,mcp__github__get_workflow_run,mcp__github__get_workflow_run_logs,mcp__github__list_branches,mcp__github__list_code_scanning_alerts,mcp__github__list_commits,mcp__github__list_dependabot_alerts,mcp__github__list_pull_requests,mcp__github__list_secret_scanning_alerts,mcp__github__list_workflow_jobs,mcp__github__list_workflow_run_artifacts,mcp__github__list_workflow_runs,mcp__github__list_workflows,mcp__github__merge_pull_request,mcp__github__push_files,mcp__github__rerun_failed_jobs,mcp__github__rerun_workflow_run,mcp__github__run_workflow,mcp__github__search_code,mcp__github__search_pull_requests,mcp__github__submit_pending_pull_request_review,mcp__github__update_pull_request,mcp__github__update_pull_request_branch,ListMcpResourcesTool,ReadMcpResourceTool"
             --disallowedTools WebSearch,WebFetch
           prompt: |
-            Please review this PR #${{ github.event.pull_request.number }} in ${{ github.repository }} with comprehensive analysis covering both general software engineering principles and OCI automation specifics:
+            Please review this PR #${{ github.event.pull_request.number }} with comprehensive analysis covering both general software engineering principles and OCI automation specifics:
 
             **General Code Quality & Best Practices:**
             - Code structure, readability, and maintainability
@@ -119,8 +122,7 @@ jobs:
             **Security Analysis (General & OCI-Specific):**
             - Input validation and injection vulnerabilities
             - Authentication and authorization patterns
-            - **OCI Credential Safety**: Check for exposed credentials (OCI OCIDs, keys, SSH keys, tokens)
-            - **Parameter redaction**: OCIDs should show as ocid1234...5678, keys as [REDACTED]
+            - **Credential Safety**: Check for exposed credentials (OCI OCIDs, keys, SSH keys, tokens)
             - Verify secrets are only used in GitHub Actions, never in artifacts
             - Distinguish capacity issues from real security failures
 
@@ -138,12 +140,8 @@ jobs:
             - Error condition testing
 
             **OCI-Specific Automation Patterns:**
-            - Validate OCID format: ^ocid1\\.type\\.[a-z0-9-]*\\.[a-z0-9-]*\\..+
-            - Check flexible shape configurations include --shape-config
             - Verify capacity errors return 0 (expected) vs 1 (real failure)
-            - Confirm transient errors retry properly before AD cycling
-            - Multi-AD cycling logic and retry mechanisms
-            - Bash script validation and OCI CLI optimization
+            - OCI CLI optimization
 
             **Potential Bugs & Issues:**
             - Race conditions and concurrency issues
@@ -153,5 +151,7 @@ jobs:
 
             Be constructive, thorough, and provide specific actionable feedback.
             Provide severity ratings (Critical/High/Medium/Low) for any issues found.
-            Use GitHub's suggestion format when proposing code changes.
-            Use inline comments to highlight specific areas of concern.
+            
+          # Disabled: creates a mess to review. Inline suggestions are often broken
+          # Use GitHub's suggestion format when proposing code changes.
+          # Use inline comments to highlight specific areas of concern.


### PR DESCRIPTION
- remove request from prompt to use github suggestions and inline comments: was not a viable addition for me, not really useful for claude code and hard to read (and I had resolve all of them before merging PRs), and claude was not enable to resolve inline comments automatically anyway (maybe it could via MCP? will try in the future).
- remove some garbage instructions from reviewer prompt (thanks claude code...)
- disable sticky comment feature (was not working anyway)
- disable signed commits feature & remove unused mcp tools from allowed list - seems to be useless for reviewer bot, as it does not react to request and does not modify anything currently (I should set up separate workflow with claude PR assistant to follow-up on reviews right from Web UI!)
- improve workflow dependency caching, include claude installer in cache (not sure it would work)