### PR TITLE
fix: eliminate unwanted preflight check notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ gh run watch <run-id>
 - ❌ Oracle capacity unavailable (expected operational condition - will retry)
 - ❌ Rate limiting (standard cloud provider behavior - will retry)
 - ❌ Instance already exists (expected when using state management cache)
+- ❌ Preflight check completion (operational validation - use silent connectivity test)
 - ❌ Any condition that resolves through automated retry cycles
 
 ### Notification Behavior:
@@ -162,6 +163,10 @@ gh run watch <run-id>
 ### Philosophy:
 **Notify for successes and actionable failures. Never notify for expected operational conditions.**
 Expected conditions (limits, capacity constraints) are normal automation behavior that resolve through retry cycles.
+
+### Configuration Variables:
+- `PREFLIGHT_SEND_TEST_NOTIFICATION=true`: Forces preflight check to send test notification (default: false)
+- Preflight checks use silent `/getMe` API endpoint for connectivity validation without generating notifications
 
 ## Linter Configuration Policy
 


### PR DESCRIPTION
## Summary
• Fixed unwanted Telegram notifications during preflight checks
• Replaced direct notification sending with silent API connectivity test
• Added explicit control via `PREFLIGHT_SEND_TEST_NOTIFICATION` environment variable

## Changes
• **scripts/preflight-check.sh**: Use `/getMe` API endpoint for silent connectivity validation
• **CLAUDE.md**: Updated notification policy documentation and configuration variables
• Maintains all validation functionality without generating notifications

## Test plan
- [x] Syntax validation passes
- [x] Silent connectivity test works without sending notifications  
- [x] Test notification can be explicitly triggered via environment variable
- [x] Documentation updated to reflect changes
- [x] Backward compatibility maintained

## Problem Solved
Resolves violation of notification policy where "operational conditions should never generate notifications." Preflight checks are now completely silent while preserving all validation capabilities.