### PR TITLE
Fix E2 limit exceeded state persistence issue causing repeated workflow failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,10 @@ gh run watch <run-id>
 - **"Too many requests"** - Oracle API throttling during high usage, workflow continues normally  
 - **"Out of host capacity"** - Common during peak usage periods
 - **ARM (A1.Flex) typically more available** than AMD (E2.1.Micro)
+- **Free tier limits reached** - Expected when E2 (2/2 instances) or A1 (4/4 OCPUs) limits are reached
+  - Limit states are cached to prevent repeated failed attempts
+  - Cached limits persist between workflow runs to avoid unnecessary Oracle API calls
+  - Workflow returns success (exit code 0) when limits are reached - not a failure condition
 
 ### OCID Validation
 ```bash

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -62,6 +62,8 @@ readonly EXIT_SUCCESS=0
 readonly EXIT_GENERAL_ERROR=1
 readonly EXIT_CAPACITY_ERROR=2        # Oracle capacity unavailable
 readonly EXIT_CONFIG_ERROR=3          # Configuration/authentication errors
+readonly EXIT_NETWORK_ERROR=4         # Network/internal errors
+readonly EXIT_USER_LIMIT_ERROR=5      # User reached free tier limits (expected success)
 readonly EXIT_RATE_LIMIT_ERROR=6      # Oracle API rate limiting (429 errors)
 readonly EXIT_TIMEOUT_ERROR=124       # GNU timeout compatibility
 


### PR DESCRIPTION
## Summary
Fixes critical workflow failures from workflow run 17363191144 where E2.1.Micro shape repeatedly attempted creation despite reaching free tier limits (2/2 instances).

## Root Cause
The `should_create_instance()` function was not checking cached limit states, causing a vicious cycle:
1. E2 encounters `LimitExceeded` → caches limit state  
2. Workflow fails → GitHub Actions cache save fails
3. Next run ignores cached limits → attempts E2 creation again → repeat

## Key Changes
- **Added limit checking to `should_create_instance()`**: Now checks cached limit states before allowing creation attempts
- **Instance name to shape mapping**: `"e2-micro-sg"` → `"VM.Standard.E2.1.Micro"`, `"a1-flex-sg"` → `"VM.Standard.A1.Flex"`
- **Environment fallback**: Uses `OCI_SHAPE` for custom instance names
- **Added missing exit code constants**: `EXIT_USER_LIMIT_ERROR=5`, `EXIT_NETWORK_ERROR=4`

## Test Plan
- [x] Comprehensive limit caching test covering all scenarios
- [x] Syntax validation of all modified scripts
- [x] Verified shape-to-instance name mapping
- [x] Confirmed workflow success logic treats user limits as expected success

## Expected Outcome
**First run after limit reached:**
- E2 hits `LimitExceeded` → caches limit → workflow succeeds (exit 0) → cache persists

**Subsequent runs:**  
- `should_create_instance("e2-micro-sg")` returns `false` → E2 skipped entirely
- No more repeated `LimitExceeded` API calls
- Only shapes without cached limits are attempted

## Impact
- ✅ Eliminates repeated failed attempts for shapes at free tier limits
- ✅ Reduces unnecessary Oracle API calls
- ✅ Prevents false workflow failures when user limits are reached
- ✅ Maintains existing duplicate prevention functionality

🤖 Generated with [Claude Code](https://claude.ai/code)