### PR TITLE
Fix workflow failure when E2 instances already exist

### DIFF
--- a/.github/workflows/infrastructure-deployment.yml
+++ b/.github/workflows/infrastructure-deployment.yml
@@ -119,15 +119,25 @@ jobs:
         id: get-date
         run: echo "date=$(date '+%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
+      - name: Generate cache key with region hash
+        id: cache-key
+        env:
+          OCI_REGION: ${{ secrets.OCI_REGION }}
+        run: |
+          # Generate region hash to match state-manager.sh logic
+          region_hash=$(echo -n "$OCI_REGION" | sha256sum | cut -d' ' -f1 | head -c 8)
+          echo "key=oci-instances-${region_hash}-v1-${{ steps.get-date.outputs.date }}" >> "$GITHUB_OUTPUT"
+          echo "prefix=oci-instances-${region_hash}-v1-" >> "$GITHUB_OUTPUT"
+
       - name: Restore instance state cache
         id: cache-instance-state
         uses: actions/cache/restore@v4.2.4
         with:
           path: .cache/oci-state
-          key: oci-instances-${{ secrets.OCI_REGION }}-v1-${{ steps.get-date.outputs.date }}
+          key: ${{ steps.cache-key.outputs.key }}
           restore-keys: |
-            oci-instances-${{ secrets.OCI_REGION }}-v1-
-            oci-instances-${{ secrets.OCI_REGION }}-
+            ${{ steps.cache-key.outputs.prefix }}
+            oci-instances-
 
       - name: Initialize state manager
         env:
@@ -252,7 +262,7 @@ jobs:
         uses: actions/cache/save@v4.2.4
         with:
           path: .cache/oci-state
-          key: oci-instances-${{ secrets.OCI_REGION }}-v1-${{ steps.get-date.outputs.date }}
+          key: ${{ steps.cache-key.outputs.key }}
 
       - name: Schedule Optimization Analysis
         if: always() && env.ENABLE_ADAPTIVE_SCHEDULING == 'true'


### PR DESCRIPTION
## Summary
Resolves workflow run 17363353915 failure where the system attempted to create E2.1.Micro instances despite already having 2/2 E2 instances in Oracle Cloud (free tier limit reached).

## Root Cause Analysis
1. **Cache key mismatch**: Workflow used raw region name while scripts used region hash
2. **Verification step errors**: Non-critical verification failures propagated to main workflow  
3. **Missing debug visibility**: Insufficient logging to diagnose limit checking decisions

## Key Changes

### 🔧 **Fixed Cache Key Mismatch** (`.github/workflows/infrastructure-deployment.yml`)
- **Before**: `oci-instances-${{ secrets.OCI_REGION }}-v1-date`
- **After**: `oci-instances-{region_hash}-v1-date` (matches script logic)
- **Result**: Proper cache persistence between workflow runs

### 🐛 **Enhanced Debug Logging** (`scripts/state-manager.sh`)
- Added comprehensive debug output to `should_create_instance()` function
- Added detailed logging to `get_cached_limit_state()` function  
- Shows complete decision process: mapping → limit checking → final decision

### 🎯 **Strengthened Instance Name Mapping** (`scripts/state-manager.sh`)
- **Method 1**: Direct mapping (`e2-micro-sg` → `VM.Standard.E2.1.Micro`)
- **Method 2**: Pattern matching (`*e2*`, `*micro*` → `VM.Standard.E2.1.Micro`)
- **Method 3**: Environment variable fallback (`OCI_SHAPE`)
- **Method 4**: Cached shape lookup from existing instance state

### ✅ **Fixed Verification Error Handling** (`scripts/launch-parallel.sh`)
- **Before**: Verification failures propagated to main workflow (exit code 1)
- **After**: Verification errors captured but non-critical (workflow continues)
- **Result**: Expected conditions (user limits, rate limits) return success

## Expected Behavior After Fix

When E2 instances already exist:
1. ✅ Cache loads with E2 limit state  
2. ✅ `should_create_instance("e2-micro-sg")` returns `false`
3. ✅ E2 creation skipped entirely
4. ✅ Workflow succeeds with exit code 0
5. ✅ No notifications for expected operational conditions

## Test Results

- ✅ Syntax validation passed for all modified scripts
- ✅ State manager limit checking works correctly
- ✅ Instance name mapping (direct + pattern) functional
- ✅ Debug logging shows complete decision process
- ✅ YAML workflow syntax validated

## Validation Commands
```bash
# Test limit checking for E2 (should skip when cached)
DEBUG=true ./scripts/state-manager.sh set-limit VM.Standard.E2.1.Micro true
DEBUG=true ./scripts/state-manager.sh check e2-micro-sg  # Returns: SKIP

# Test pattern matching
DEBUG=true ./scripts/state-manager.sh check my-e2-instance  # Maps to E2.1.Micro
```

The workflow will now **never attempt to create instances when free tier limits are cached**, preventing the exact failure scenario from run 17363353915.

🤖 Generated with [Claude Code](https://claude.ai/code)